### PR TITLE
Update output pathing to use more descriptive names

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -55,7 +55,9 @@ class PolygonPipeline:
         # Store tags dict directly - pipeline stages will create tag strings as needed
         self.tmp = tempfile.TemporaryDirectory(prefix="pipeline-", dir=temp_dir)
 
-        self.path_factory = PathFactory(config, outputs_path)
+        # Get aoi_name from tags for the PathFactory
+        aoi_name = self.tags["aoi_name"]  # Required tag, will always exist
+        self.path_factory = PathFactory(config, outputs_path, aoi_name)
 
         # Populated by initialize()
         self.catchments: Dict[str, Dict[str, Any]] = {}

--- a/src/pipeline_stages.py
+++ b/src/pipeline_stages.py
@@ -203,9 +203,10 @@ class InundationStage(PipelineStage):
         if not local_parquet:
             raise ValueError(f"No parquet_path found for catchment {catch_id}")
 
+        # Parquet files are stored in catchment-data-indices directory
         parquet_path = await self.data_svc.copy_file_to_uri(
             local_parquet,
-            self.path_factory.inundation_parquet_path(result.collection_name, result.scenario_name, catch_id),
+            self.path_factory.catchment_parquet_path(catch_id),
         )
         flowfile_s3_path = await self.data_svc.copy_file_to_uri(
             result.flowfile_path, self.path_factory.flowfile_path(result.collection_name, result.scenario_name)

--- a/src/pipeline_utils.py
+++ b/src/pipeline_utils.py
@@ -36,9 +36,10 @@ class PipelineResult:
 class PathFactory:
     """Centralized path generation for pipeline stages, supporting both local and S3 paths."""
 
-    def __init__(self, config: AppConfig, outputs_path: str):
+    def __init__(self, config: AppConfig, outputs_path: str, aoi_name: str):
         self.config = config
-        
+        self.aoi_name = aoi_name
+
         # Use provided outputs_path (local or S3) - this should already include the HUC directory
         if outputs_path.startswith("s3://"):
             self.base = outputs_path.rstrip('/')
@@ -52,34 +53,57 @@ class PathFactory:
         return f"{self.base}/{collection_name}/{scenario_name}/{filename}"
 
     def catchment_path(self, collection_name: str, scenario_name: str, catchment_id: str, filename: str) -> str:
-        """Generate path: base/SOURCE/SCENARIO/catchments/catchment-ID/filename"""
-        return f"{self.base}/{collection_name}/{scenario_name}/catchments/catchment-{catchment_id}/{filename}"
+        """Generate path: base/SOURCE/SCENARIO/catchment-extents/filename"""
+        return f"{self.base}/{collection_name}/{scenario_name}/catchment-extents/{filename}"
 
     def inundation_output_path(self, collection_name: str, scenario_name: str, catchment_id: str) -> str:
-        return self.catchment_path(collection_name, scenario_name, catchment_id, f"catchment-{catchment_id}.tif")
+        filename = f"{collection_name}__{scenario_name}__catchment-{catchment_id}.tif"
+        return self.catchment_path(collection_name, scenario_name, catchment_id, filename)
 
-    def inundation_parquet_path(self, collection_name: str, scenario_name: str, catchment_id: str) -> str:
-        return self.catchment_path(collection_name, scenario_name, catchment_id, f"catchment-{catchment_id}.parquet")
+    def catchment_data_indices_dir(self) -> str:
+        """Generate path for catchment data indices directory: base/catchment-data-indices/"""
+        return f"{self.base}/catchment-data-indices"
+
+    def catchment_parquet_path(self, catchment_id: str) -> str:
+        """Generate path for catchment parquet file: base/catchment-data-indices/catchment-{id}.parquet"""
+        return f"{self.catchment_data_indices_dir()}/catchment-{catchment_id}.parquet"
 
     def flowfile_path(self, collection_name: str, scenario_name: str) -> str:
-        return self.source_scenario_path(collection_name, scenario_name, "flowfile.csv")
+        filename = f"{self.aoi_name}__{collection_name}__{scenario_name}__flowfile.csv"
+        return self.source_scenario_path(collection_name, scenario_name, filename)
 
     def hand_mosaic_path(self, collection_name: str, scenario_name: str) -> str:
-        return self.source_scenario_path(collection_name, scenario_name, "inundate_mosaic.tif")
+        filename = f"{self.aoi_name}__{collection_name}__{scenario_name}__inundate_mosaic.tif"
+        return self.source_scenario_path(collection_name, scenario_name, filename)
 
     def benchmark_mosaic_path(self, collection_name: str, scenario_name: str) -> str:
-        return self.source_scenario_path(collection_name, scenario_name, "benchmark_mosaic.tif")
+        filename = f"{self.aoi_name}__{collection_name}__{scenario_name}__benchmark_mosaic.tif"
+        return self.source_scenario_path(collection_name, scenario_name, filename)
 
     def agreement_map_path(self, collection_name: str, scenario_name: str) -> str:
-        return self.source_scenario_path(collection_name, scenario_name, "agreement.tif")
+        filename = f"{self.aoi_name}__{collection_name}__{scenario_name}__agreement.tif"
+        return self.source_scenario_path(collection_name, scenario_name, filename)
 
     def agreement_metrics_path(self, collection_name: str, scenario_name: str) -> str:
-        return self.source_scenario_path(collection_name, scenario_name, "metrics.csv")
-    
+        filename = f"{self.aoi_name}__{collection_name}__{scenario_name}__metrics.csv"
+        return self.source_scenario_path(collection_name, scenario_name, filename)
+
     def logs_path(self) -> str:
-        """Generate path for pipeline logs: base/logs.txt"""
-        return f"{self.base}/logs.txt"
-    
+        """Generate path for pipeline logs: base/{aoi}__logs.txt"""
+        filename = f"{self.aoi_name}__logs.txt"
+        return f"{self.base}/{filename}"
+
     def results_path(self) -> str:
-        """Generate path for aggregated results: base/agg_metrics.csv"""
-        return f"{self.base}/agg_metrics.csv"
+        """Generate path for aggregated results: base/{aoi}__agg_metrics.csv"""
+        filename = f"{self.aoi_name}__agg_metrics.csv"
+        return f"{self.base}/{filename}"
+
+    def results_json_path(self) -> str:
+        """Generate path for pipeline results JSON: base/{aoi}__results.json"""
+        filename = f"{self.aoi_name}__results.json"
+        return f"{self.base}/{filename}"
+
+    def aoi_path(self) -> str:
+        """Generate path for AOI file: base/{aoi}__aoi.gpkg"""
+        filename = f"{self.aoi_name}__aoi.gpkg"
+        return f"{self.base}/{filename}"


### PR DESCRIPTION
This PR implements: 
1. The new output filenames described in https://github.com/NGWPC/autoeval-coordinator/issues/9#issuecomment-3117833027 
2. Moves the catchment parquet up to the top level of the repo