### PR TITLE
Edit local docker compose and requirements.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ pipeline_log.db
 viztracer-visualization.json
 pipeline_trace.json
 .data
+cache/aiohttp_cache.sqlite
+reports/

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -64,6 +64,8 @@ services:
       # cgroup filesystem access required for Nomad client to manage process isolation and resource limits
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
       - /tmp:/tmp
+      # Docker container logs directory for Nomad to read container logs
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
     environment:
       - NOMAD_ADDR=${NOMAD_ADDR}
     command: ["nomad", "agent", "-config", "/etc/nomad/nomad.hcl"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiobotocore==2.23.0
 aiohappyeyeballs==2.6.1
-aiohttp==3.11.17
+aiohttp>3.11.17
 aiohttp-sse-client==0.2.1
 aioitertools==0.12.0
 aiosignal==1.3.2


### PR DESCRIPTION
This is a small PR that makes the following edits to `docker-compose-local.yml`, `.gitignore` and `requirements.txt`:

Add a volume to local nomad server to retain logs

Drop jinja2 from requirements. Not needed anymore with new reporting

Update gitignore to reflect the gitignore during ripple batch production