### PR TITLE
Update job definitions

### DIFF
--- a/job_defs/local/agreement_maker.nomad
+++ b/job_defs/local/agreement_maker.nomad
@@ -25,10 +25,14 @@ job "agreement_maker" {
   }
 
   group "agreement-processor" {
-    # Don't attempt restart since don't want to retry on most errors
+    reschedule {
+      attempts = 0 # this needs to only be 0 re-attempts or will mess up pipeline job tracking
+    }
+
     restart {
-      attempts = 0
-      mode     = "fail"
+      attempts = 3        # Try N times on the same node
+      delay    = "15s"    # Wait between attempts
+      mode     = "fail"   # Fail after attempts exhausted
     }
 
     task "processor" {
@@ -44,7 +48,8 @@ job "agreement_maker" {
         # Mount local test data and output directory
         volumes = [
           "${var.repo_root}/testdata:/testdata:ro",
-          "/tmp/autoeval-outputs:/outputs:rw"
+          "/tmp/autoeval-outputs:/outputs:rw",
+          "${var.repo_root}/local-batches:/local-batches:rw"
         ]
         
         command = "python3"
@@ -55,7 +60,7 @@ job "agreement_maker" {
           "--benchmark_path", "${NOMAD_META_benchmark_path}",
           "--output_path", "${NOMAD_META_output_path}",
           "--metrics_path", "${NOMAD_META_metrics_path}",
-          "--clip_geoms", "${NOMAD_META_clip_geoms}",
+          "--mask_dict", "s3://fimc-data/autoeval/test_data/mask_areas.json",
         ]
 
       }
@@ -79,9 +84,9 @@ job "agreement_maker" {
         CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE = "YES"
         
         # Processing Configuration
-        DASK_CLUST_MAX_MEM = "12GB"
-        RASTERIO_CHUNK_SIZE = "4096"
-        DEFAULT_WRITE_BLOCK_SIZE = "4096"
+        DASK_CLUST_MAX_MEM = "27GB"
+        RASTERIO_CHUNK_SIZE = "2048"
+        DEFAULT_WRITE_BLOCK_SIZE = "1024"
         COG_BLOCKSIZE = "512"
         COG_OVERVIEW_LEVEL = "4"
         
@@ -96,8 +101,7 @@ job "agreement_maker" {
       }
 
       resources {
-        # set small here for github runner test (8gb total memory)
-        memory = 4000 
+        memory = 28000 
       }
 
       logs {

--- a/job_defs/local/fim_mosaicker.nomad
+++ b/job_defs/local/fim_mosaicker.nomad
@@ -18,13 +18,20 @@ job "fim_mosaicker" {
       "aws_access_key",
       "aws_secret_key",
       "aws_session_token",
+      "clip_geometry_path",
     ]
   }
 
   group "mosaicker-processor" {
+
+    reschedule {
+      attempts = 0 # this needs to only be 0 re-attempts or will mess up pipeline job tracking
+    }
+
     restart {
-      attempts = 0
-      mode     = "fail"
+      attempts = 3        # Try N times on the same node
+      delay    = "15s"    # Wait between attempts
+      mode     = "fail"   # Fail after attempts exhausted
     }
 
     task "processor" {
@@ -40,7 +47,8 @@ job "fim_mosaicker" {
         # Mount local test data and output directory
         volumes = [
           "${var.repo_root}/testdata:/testdata:ro",
-          "/tmp/autoeval-outputs:/outputs:rw"
+          "/tmp/autoeval-outputs:/outputs:rw",
+          "${var.repo_root}/local-batches:/local-batches:rw"
         ]
 
         command = "python3"
@@ -49,6 +57,7 @@ job "fim_mosaicker" {
           "--raster_paths", "${NOMAD_META_raster_paths}",
           "--mosaic_output_path", "${NOMAD_META_output_path}",
           "--fim_type", "${NOMAD_META_fim_type}",
+          "--clip_geometry_path", "${NOMAD_META_clip_geometry_path}",
         ]
 
       }
@@ -58,7 +67,6 @@ job "fim_mosaicker" {
         AWS_SECRET_ACCESS_KEY = "${NOMAD_META_aws_secret_key}"
         AWS_SESSION_TOKEN     = "${NOMAD_META_aws_session_token}"
         AWS_DEFAULT_REGION = "us-east-1"
-        GDAL_CACHEMAX         = "1024"
         
         # GDAL Configuration
         GDAL_NUM_THREADS = "1"
@@ -66,7 +74,9 @@ job "fim_mosaicker" {
         GDAL_DISABLE_READDIR_ON_OPEN = "TRUE"
         CPL_LOG_ERRORS = "ON"
         CPL_VSIL_CURL_ALLOWED_EXTENSIONS = ".tif,.vrt"
-        VSI_CACHE_SIZE = "268435456"
+        VSI_CACHE_SIZE = "512000000" # s3 data cache size
+        GDAL_SWATH_SIZE = "512000000"  # swath size for translate operations
+        GDAL_CACHEMAX = "2048"
         CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE = "YES"
         
         # Output Configuration
@@ -83,8 +93,6 @@ job "fim_mosaicker" {
       }
 
       resources {
-        cpu    = 1000 
-        # set small here for github runner test (8gb total memory)
         memory = 4000 
       }
 

--- a/job_defs/local/hand_inundator.nomad
+++ b/job_defs/local/hand_inundator.nomad
@@ -23,10 +23,14 @@ job "hand_inundator" {
   }
 
   group "inundator-processor" {
-    # Don't attempt restart since don't want to retry on most errors
+    reschedule {
+      attempts = 0 # this needs to only be 0 re-attempts or will mess up pipeline job tracking
+    }
+
+    # inundate fails for predictible reasons. Restarting takes alot of time. Will rely on manually querying inundate job failures in AWS console to detect if a batch had inundate failures that were novel.
     restart {
-      attempts = 0
-      mode     = "fail"
+      attempts = 0        # Try N times on the same node
+      mode     = "fail"   # Fail after attempts exhausted
     }
 
     task "processor" {
@@ -42,7 +46,8 @@ job "hand_inundator" {
         volumes = [
           "${var.repo_root}/testdata:/testdata:ro",
           "/tmp/autoeval-outputs:/outputs:rw",
-          "/tmp:/tmp:rw"
+          "/tmp:/tmp:rw",
+          "${var.repo_root}/local-batches:/local-batches:rw"
         ]
         
         command = "python3"

--- a/job_defs/test/agreement_maker.nomad
+++ b/job_defs/test/agreement_maker.nomad
@@ -2,6 +2,11 @@ job "agreement_maker" {
   datacenters = ["dc1"] 
   type        = "batch"
 
+  constraint {
+    attribute = "${node.class}"
+    value     = "linux"
+  }
+
   parameterized {
     meta_required = [
       "candidate_path", 
@@ -20,10 +25,14 @@ job "agreement_maker" {
   }
 
   group "agreement-processor" {
-    # Don't attempt restart since don't want to retry on most errors
+    reschedule {
+      attempts = 0 # this needs to only be 0 re-attempts or will mess up pipeline job tracking
+    }
+
     restart {
-      attempts = 0
-      mode     = "fail"
+      attempts = 3        # Try N times on the same node
+      delay    = "15s"    # Wait between attempts
+      mode     = "fail"   # Fail after attempts exhausted
     }
 
     task "processor" {
@@ -31,7 +40,8 @@ job "agreement_maker" {
 
       config {
         image = "registry.sh.nextgenwaterprediction.com/ngwpc/fim-c/flows2fim_extents:autoeval-jobs-gval-v0.2" 
-        force_pull = true
+        force_pull = false
+        # force_pull = true # use a cached image on client if available. To force a pull need to change back to force_pull = true
 
         auth {
           username = "ReadOnly_NGWPC_Group_Deploy_Token" # Or your specific username
@@ -45,15 +55,24 @@ job "agreement_maker" {
           "--benchmark_path", "${NOMAD_META_benchmark_path}",
           "--output_path", "${NOMAD_META_output_path}",
           "--metrics_path", "${NOMAD_META_metrics_path}",
-          "--clip_geoms", "${NOMAD_META_clip_geoms}",
+          "--mask_dict", "s3://fimc-data/autoeval/test_data/mask_areas.json",
         ]
 
+        logging {
+          type = "awslogs"
+          config {
+            awslogs-group        = "/aws/ec2/nomad-client-linux-test"
+            awslogs-region       = "us-east-1"
+            awslogs-stream       = "${NOMAD_JOB_ID}"
+            awslogs-create-group = "true"
+          }
+        }
       }
 
       env {
-        AWS_ACCESS_KEY_ID     = "${NOMAD_META_aws_access_key}"
-        AWS_SECRET_ACCESS_KEY = "${NOMAD_META_aws_secret_key}"
-        AWS_SESSION_TOKEN     = "${NOMAD_META_aws_session_token}"
+        # AWS_ACCESS_KEY_ID     = "${NOMAD_META_aws_access_key}"
+        # AWS_SECRET_ACCESS_KEY = "${NOMAD_META_aws_secret_key}"
+        # AWS_SESSION_TOKEN     = "${NOMAD_META_aws_session_token}"
         AWS_DEFAULT_REGION = "us-east-1"
         GDAL_CACHEMAX         = "1024"
         
@@ -67,9 +86,9 @@ job "agreement_maker" {
         CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE = "YES"
         
         # Processing Configuration
-        DASK_CLUST_MAX_MEM = "12GB"
-        RASTERIO_CHUNK_SIZE = "4096"
-        DEFAULT_WRITE_BLOCK_SIZE = "4096"
+        DASK_CLUST_MAX_MEM = "30GB"
+        RASTERIO_CHUNK_SIZE = "2048"
+        DEFAULT_WRITE_BLOCK_SIZE = "1024"
         COG_BLOCKSIZE = "512"
         COG_OVERVIEW_LEVEL = "4"
         
@@ -84,7 +103,7 @@ job "agreement_maker" {
       }
 
       resources {
-        memory = 12000 # Higher memory for large raster processing
+        memory = 30500 # Higher memory for large raster processing. This should be DASK_CLUST_MAX_MEM + a bit more. Setting this to a bit higher than the max memory usage seen from agreement job while processing ripple data. For 10m this should be ~12gb, for 5m 18-20 gb, and for 3m 25-30gb
       }
 
       logs {

--- a/job_defs/test/fim_mosaicker.nomad
+++ b/job_defs/test/fim_mosaicker.nomad
@@ -18,13 +18,19 @@ job "fim_mosaicker" {
       "aws_access_key",
       "aws_secret_key",
       "aws_session_token",
+      "clip_geometry_path",
     ]
   }
 
   group "mosaicker-processor" {
+    reschedule {
+      attempts = 0 # this needs to only be 0 re-attempts or will mess up pipeline job tracking
+    }
+
     restart {
-      attempts = 0
-      mode     = "fail"
+      attempts = 3        # Try N times on the same node
+      delay    = "15s"    # Wait between attempts
+      mode     = "fail"   # Fail after attempts exhausted
     }
 
     task "processor" {
@@ -33,7 +39,8 @@ job "fim_mosaicker" {
       config {
         # use last known stable version in test
         image = "registry.sh.nextgenwaterprediction.com/ngwpc/fim-c/flows2fim_extents:autoeval-jobs-v0.2" 
-        force_pull = true
+        # force_pull = false # use a cached image on client if available. To force a pull need to change back to force_pull = true
+        force_pull = true 
 
         auth {
           username = "ReadOnly_NGWPC_Group_Deploy_Token"
@@ -46,6 +53,8 @@ job "fim_mosaicker" {
           "--raster_paths", "${NOMAD_META_raster_paths}",
           "--mosaic_output_path", "${NOMAD_META_output_path}",
           "--fim_type", "${NOMAD_META_fim_type}",
+          "--clip_geometry_path", "${NOMAD_META_clip_geometry_path}",
+          "--parallel_blocks", "4",
         ]
 
         logging {
@@ -61,19 +70,29 @@ job "fim_mosaicker" {
 
       env {
         AWS_DEFAULT_REGION = "us-east-1"
-        GDAL_CACHEMAX         = "1024"
+        # AWS_ACCESS_KEY_ID     = "${NOMAD_META_aws_access_key}"
+        # AWS_SECRET_ACCESS_KEY = "${NOMAD_META_aws_secret_key}"
+        # AWS_SESSION_TOKEN     = "${NOMAD_META_aws_session_token}"
+
         
         # GDAL Configuration
-        GDAL_NUM_THREADS = "1"
+        GDAL_NUM_THREADS = "4"
         GDAL_TIFF_DIRECT_IO = "YES"
         GDAL_DISABLE_READDIR_ON_OPEN = "TRUE"
         CPL_LOG_ERRORS = "ON"
         CPL_VSIL_CURL_ALLOWED_EXTENSIONS = ".tif,.vrt"
-        VSI_CACHE_SIZE = "268435456"
+        VSI_CACHE_SIZE = "512000000" # s3 data cache size
+        GDAL_SWATH_SIZE = "4294967296"  # 4096 MB (4 GB) for translate operations and copying data between raster datasets
+        GDAL_CACHEMAX = "2048"
         CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE = "YES"
+
+        # Set retry explicitely to ensure mosaic retries blocks when it hits s3 throttling.
+        GDAL_HTTP_MAX_RETRY =  "2"
+        GDAL_HTTP_RETRY_DELAY = "5"
+        GDAL_HTTP_RETRY_CODES =  "ALL"
         
         # Output Configuration
-        MOSAIC_BLOCK_SIZE = "512"
+        MOSAIC_BLOCK_SIZE = "2048" # use bigger blocks to boost the  effect of using multiple threads
         MOSAIC_COMPRESS_TYPE = "LZW"
         MOSAIC_PREDICTOR = "2"
         
@@ -84,7 +103,7 @@ job "fim_mosaicker" {
       }
 
       resources {
-        memory = 6048
+        memory = 14000 #Be generous here to avoid OOM. For 10m this should be 10 gb, 12 gb for 5m, 16-18gb for 10m 
       }
 
       logs {

--- a/job_defs/test/hand_inundator.nomad
+++ b/job_defs/test/hand_inundator.nomad
@@ -23,10 +23,15 @@ job "hand_inundator" {
   }
 
   group "inundator-processor" {
-    # Don't attempt restart since don't want to retry on most errors
+    reschedule {
+      attempts = 0 # this needs to only be 0 re-attempts or will mess up pipeline job tracking
+    }
+
+    # inundate fails for predictible reasons. Restarting takes alot of time. Will rely on manually querying inundate job failures in AWS console to detect if a batch had inundate failures that were novel.
     restart {
-      attempts = 0
-      mode     = "fail"
+      attempts = 0        # Try N times on the same node
+      delay    = "15s"    # Wait between attempts
+      mode     = "fail"   # Fail after attempts exhausted
     }
 
     task "processor" {
@@ -35,7 +40,8 @@ job "hand_inundator" {
       config {
         # use last known stable version in test
         image = "registry.sh.nextgenwaterprediction.com/ngwpc/fim-c/flows2fim_extents:autoeval-jobs-v0.2" 
-        force_pull = true
+        force_pull = false
+        # force_pull = true # use a cached image on client if available. To force a pull need to change back to force_pull = true
 
         auth {
           username = "ReadOnly_NGWPC_Group_Deploy_Token" # Or your specific username
@@ -63,6 +69,10 @@ job "hand_inundator" {
 
       env {
         AWS_DEFAULT_REGION = "us-east-1"
+        # AWS_ACCESS_KEY_ID     = "${NOMAD_META_aws_access_key}"
+        # AWS_SECRET_ACCESS_KEY = "${NOMAD_META_aws_secret_key}"
+        # AWS_SESSION_TOKEN     = "${NOMAD_META_aws_session_token}"
+
         GDAL_CACHEMAX         = "1024"
         
         # GDAL Configuration
@@ -90,8 +100,7 @@ job "hand_inundator" {
       }
 
       resources {
-        cpu    = 1000 # CPU in MHz (example: 1000 = 1 GHz)
-        memory = 2048 # Memory in MiB 
+        memory = 2000 # Memory in MiB. 
       }
 
       logs {

--- a/job_defs/test/pipeline.nomad
+++ b/job_defs/test/pipeline.nomad
@@ -1,17 +1,18 @@
-variable "repo_root" {
-  description = "Path to the repository root directory"
-  type        = string
-}
-
 job "pipeline" {
   datacenters = ["dc1"] 
   type        = "batch"
+
+  constraint {
+    attribute = "${node.class}"
+    value     = "linux"
+  }
 
   parameterized {
     meta_required = [
       "aoi",              
       "outputs_path",     
-      "hand_index_path",  
+      "hand_index_path",
+      "nomad_token",     # Required for test environment
     ]
     meta_optional = [
       "benchmark_sources",# Comma-separated list 
@@ -21,12 +22,12 @@ job "pipeline" {
       "aws_secret_key", 
       "aws_session_token",
       "stac_datetime_filter", 
-      "nomad_token",     # Required for test environment dispatch never used here
       "tags",            # Space-separated list of key=value pairs
     ]
   }
 
   group "pipeline-coordinator" {
+
     # don't reschedule or reattempt a failed pipeline. Just want until the next batch run. This saves on compute and makes it easier to scrape logs for failures.
   
     reschedule {
@@ -41,19 +42,16 @@ job "pipeline" {
       driver = "docker"
 
       config {
-        # Use local development image - must use specific tag (not 'latest')
-        # to prevent Nomad from trying to pull from a registry
-        image = "autoeval-coordinator:local" 
+        image = "registry.sh.nextgenwaterprediction.com/ngwpc/fim-c/flows2fim_extents:autoeval-coordinator-v0.1"
         force_pull = false
+        # force_pull = true # use a cached image on client if available. To force a pull need to change back to force_pull = true
         network_mode = "host"
         
-        # Mount local test data and output directory
-        volumes = [
-          "${var.repo_root}/testdata:/testdata:ro",
-          "/tmp/autoeval-outputs:/outputs:rw",
-          "/tmp:/tmp:rw",
-          "${var.repo_root}/local-batches:/local-batches:rw"
-        ]
+        # Docker registry authentication
+        auth {
+          username = "ReadOnly_NGWPC_Group_Deploy_Token"
+          password = "${NOMAD_META_registry_token}"
+        }
 
         args = [
           "--aoi", "${NOMAD_META_aoi}",
@@ -63,7 +61,17 @@ job "pipeline" {
           "--tags", "${NOMAD_META_tags}",
           # remove this if test cases don't correspond to unique Benchmark STAC items
           "--aoi_is_item",
-          ]
+        ]
+
+        logging {
+          type = "awslogs"
+          config {
+            awslogs-group        = "/aws/ec2/nomad-client-linux-test"
+            awslogs-region       = "us-east-1"
+            awslogs-stream       = "${NOMAD_JOB_ID}"
+            awslogs-create-group = "true"
+          }
+        }
       }
 
       env {
@@ -71,29 +79,28 @@ job "pipeline" {
         NOMAD_PIPELINE_JOB_ID = "${NOMAD_JOB_ID}"
         
         # AWS Configuration
-        AWS_ACCESS_KEY_ID     = "${NOMAD_META_aws_access_key}"
-        AWS_SECRET_ACCESS_KEY = "${NOMAD_META_aws_secret_key}"
-        AWS_SESSION_TOKEN     = "${NOMAD_META_aws_session_token}"
-        AWS_DEFAULT_REGION    = "us-east-1"
-        
+        # Test nomad clients can use IAM
+        AWS_DEFAULT_REGION    = "us-east-1"      
+        # AWS_ACCESS_KEY_ID     = "${NOMAD_META_aws_access_key}"
+        # AWS_SECRET_ACCESS_KEY = "${NOMAD_META_aws_secret_key}"
+        # AWS_SESSION_TOKEN     = "${NOMAD_META_aws_session_token}"
+
         # Nomad Configuration
-        NOMAD_ADDRESS         = "http://127.0.0.1:4646"
-        NOMAD_TOKEN           = "${NOMAD_TOKEN}" # this will be changed to a meta variable when the test version of the job is created
+        NOMAD_ADDRESS         = "http://nomad-server-test.test.nextgenwaterprediction.com:4646/"
+        NOMAD_TOKEN           = "${NOMAD_META_nomad_token}" # Changed to use meta parameter for test
         NOMAD_NAMESPACE       = "default"
-        NOMAD_REGISTRY_TOKEN  = "${NOMAD_META_registry_token}"
+        NOMAD_REGISTRY_TOKEN        = "${NOMAD_META_registry_token}"
  
         # Pipeline Configuration
         FIM_TYPE              = "extent"
         HTTP_CONNECTION_LIMIT = "100"
         
         # HAND Index Configuration
-        HAND_INDEX_OVERLAP_THRESHOLD_PERCENT = "1.0"
+        HAND_INDEX_OVERLAP_THRESHOLD_PERCENT = "1.0" # Be generous in what gets included here
         
         # STAC Configuration
-        # STAC_API_URL          = "http://127.0.0.1:8888/" # local test api
-        # STAC_API_URL            = "http://127.0.0.1:8082/" # local api that can be used to query full benchmark STAC
-        STAC_API_URL            = "http://benchmark-stac.test.nextgenwaterprediction.com:8000/" # STAC api served from AWS test account that can be used to query full benchmark STAC
-        STAC_OVERLAP_THRESHOLD_PERCENT = "90.0"
+        STAC_API_URL            = "http://benchmark-stac.test.nextgenwaterprediction.com:8000/" # Using production STAC API for test
+        STAC_OVERLAP_THRESHOLD_PERCENT = "90.0" # set high when doing evals per STAC item. Only want one STAC item per eval
         STAC_DATETIME_FILTER  = "${NOMAD_META_stac_datetime_filter}"
         
         # Job Names for dispatching child jobs
@@ -108,7 +115,7 @@ job "pipeline" {
       }
 
       resources {
-        memory = 3000 
+        memory = 3000  
       }
 
       logs {


### PR DESCRIPTION
Bring job definitions up to date with the Test account job definitions used to do the ripple evals.

The local job definitions have been partially updated but more changes will be forthcoming during the port of local functionality to parallelworks